### PR TITLE
changed `DisplayField.display_format` to 1-M, added formatting to totals

### DIFF
--- a/report_builder/migrations/0008_auto__add_field_report_description__chg_field_displayfield_display_for.py
+++ b/report_builder/migrations/0008_auto__add_field_report_description__chg_field_displayfield_display_for.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'DisplayField', fields ['display_format']
+        db.delete_unique('report_builder_displayfield', ['display_format_id'])
+
+        # Changing field 'DisplayField.display_format'
+        db.alter_column('report_builder_displayfield', 'display_format_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['report_builder.Format'], null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'DisplayField.display_format'
+        db.alter_column('report_builder_displayfield', 'display_format_id', self.gf('django.db.models.fields.related.OneToOneField')(to=orm['report_builder.Format'], unique=True, null=True))
+        # Adding unique constraint on 'DisplayField', fields ['display_format']
+        db.create_unique('report_builder_displayfield', ['display_format_id'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'report_builder.displayfield': {
+            'Meta': {'ordering': "['position']", 'object_name': 'DisplayField'},
+            'aggregate': ('django.db.models.fields.CharField', [], {'max_length': '5', 'blank': 'True'}),
+            'display_format': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['report_builder.Format']", 'null': 'True', 'blank': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'field_verbose': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'group': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'path_verbose': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'report': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['report_builder.Report']"}),
+            'sort': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'sort_reverse': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'total': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'width': ('django.db.models.fields.IntegerField', [], {'default': '15'})
+        },
+        'report_builder.filterfield': {
+            'Meta': {'ordering': "['position']", 'object_name': 'FilterField'},
+            'exclude': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'field_verbose': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'filter_type': ('django.db.models.fields.CharField', [], {'default': "'icontains'", 'max_length': '20', 'blank': 'True'}),
+            'filter_value': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'filter_value2': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'path': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'path_verbose': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            'position': ('django.db.models.fields.PositiveSmallIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'report': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['report_builder.Report']"})
+        },
+        'report_builder.format': {
+            'Meta': {'object_name': 'Format'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '50', 'blank': 'True'}),
+            'string': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '300', 'blank': 'True'})
+        },
+        'report_builder.report': {
+            'Meta': {'object_name': 'Report'},
+            'created': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'distinct': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'root_model': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'starred': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'report_starred_set'", 'blank': 'True', 'to': "orm['auth.User']"}),
+            'user_created': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'user_modified': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'report_modified_set'", 'null': 'True', 'to': "orm['auth.User']"})
+        }
+    }
+
+    complete_apps = ['report_builder']

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -159,7 +159,7 @@ class DisplayField(models.Model):
     position = models.PositiveSmallIntegerField(blank = True, null = True)
     total = models.BooleanField(default=False)
     group = models.BooleanField(default=False)
-    display_format = models.OneToOneField(Format, blank=True, null=True)
+    display_format = models.ForeignKey(Format, blank=True, null=True)
 
     class Meta:
         ordering = ['position']

--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -326,6 +326,7 @@ def report_to_list(report, user, preview=False):
         if display_field.total:
             display_totals[display_field_key] = {'val': Decimal('0.00')}
 
+
     for i, display_field in enumerate(report.displayfield_set.all()):
         model = get_model_from_path_string(model_class, display_field.path)
         if user.has_perm(model._meta.app_label + '.change_' + model._meta.module_name) \
@@ -479,6 +480,13 @@ def report_to_list(report, user, preview=False):
             if df.display_format:
                 display_formats.update({df.position: df.display_format}) 
         for row in values_and_properties_list:
+            # add display totals for grouped result sets
+            # TODO: dry this up, duplicated logic in non-grouped total routine 
+            if group:
+                # increment totals for fields
+                for i, field in enumerate(display_field_paths[1:]):
+                    if field in display_totals.keys():
+                        increment_total(field, display_totals, row[i])
             row = list(row)
             for position, choice_list in choice_lists.iteritems():
                 row[position-1] = choice_list[row[position-1]]
@@ -487,14 +495,6 @@ def report_to_list(report, user, preview=False):
             final_list.append(row)
         values_and_properties_list = final_list
 
-
-        # add display totals for grouped result sets
-        if group:
-            # increment totals for fields
-            for row in values_and_properties_list: 
-                for i, field in enumerate(display_field_paths[1:]):
-                    if field in display_totals.keys():
-                        increment_total(field, display_totals, row[i])
 
         if display_totals:
             display_totals_row = []
@@ -508,12 +508,20 @@ def report_to_list(report, user, preview=False):
                 else:
                     display_totals_row += ['']
 
+        # add formatting to display totals
+        for df in report.displayfield_set.all():
+            if df.display_format:
+                display_totals_row[df.position-1] = df.display_format.string.format(
+                    display_totals_row[df.position-1]
+                    )
+
         if display_totals:
             values_and_properties_list = (
                 values_and_properties_list + [
                     ['TOTALS'] + (len(fields_and_properties) - 1) * ['']
                     ] + [display_totals_row]
                 )
+
                 
 
     except exceptions.FieldError:


### PR DESCRIPTION
I meant to constrain a `DisplayField` to a single `Format`, but a `OneToOneField` constrains in both directions, which would disallow the same format to be added to more than one `DisplayField`.

The `Select` widget should enforce what I want through the UI, at least.
