### PR TITLE
When copying a report in Python 2.6.8, a ValueError gets thrown

### DIFF
--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -724,7 +724,7 @@ def create_copy(request, pk):
     """ Copy a report including related fields """
     report = get_object_or_404(Report, pk=pk)
     new_report = duplicate(report, changes=(
-        ('name', '{} (copy)'.format(report.name)),
+        ('name', '{0} (copy)'.format(report.name)),
         ('user_created', request.user),
         ('user_modified', request.user),
     ))


### PR DESCRIPTION
A simple change to the format string makes everything operate correctly.

This fixes that problem.

(Edit this was getting associated with an issue in your queue rather than mine)
