### PR TITLE
Adds "Load url from future" in order to not crash on Django 1.4.2

### DIFF
--- a/report_builder/templates/report_builder/export_to_report.html
+++ b/report_builder/templates/report_builder/export_to_report.html
@@ -1,5 +1,5 @@
 {% extends "report_builder/base.html" %}
-
+{% load url from future %}
 {% block content %}
     <script src="{{ STATIC_URL }}report_builder/js/jquery-1.8.2.min.js" type="text/javascript" ></script>
     <script src="{{ STATIC_URL }}report_builder/js/report_form.js" type="text/javascript" ></script>


### PR DESCRIPTION
On Django 1.4.2 you get a
 NoReverseMatch at /report_builder/export_to_report/ 
u'"admin' is not a registered namespace

error when exporting. This adds retrocompatibility with Django 1.4.2.
