### PR TITLE
Fixed row totals bug when incompatible format string is in effect.

### DIFF
--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -579,8 +579,14 @@ def report_to_list(report, user, preview=False, queryset=None):
                         value = Decimal(display_totals_row[df.position-1])
                     except:
                         value = display_totals_row[df.position-1]
-                    display_totals_row[df.position-1] = df.display_format.string.\
-                        format(value)
+                    # Fall back to original value if format string and value
+                    # aren't compatible, e.g. a numerically-oriented format
+                    # string with value which is not numeric.
+                    try:
+                        value = df.display_format.string.format(value)
+                    except ValueError:
+                        pass
+                    display_totals_row[df.position-1] = value
 
         if display_totals:
             values_and_properties_list = (


### PR DESCRIPTION
When a totals row is needed _and_ one or more fields use custom formatting but are _not_ part of the totals row...an error happens.  There may be other combinations which trigger it, not sure; that's the only situation I needed to handle immediately...
