### PR TITLE
Added support for setting custom global model manager in settings using ...

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -27,7 +27,15 @@ You may include and exclude fields or entire models.::
 You may also limit which fields in a model can be used. Just add this property to a model::
 
     report_builder_exclude_fields = () # Lists or tuple of excluded fields
-    
+
+You may set a custom model manager for all models::
+
+    REPORT_BUILDER_MODEL_MANAGER = 'on_site' #name of custom model manager to use on all models
+
+You many also set a custom model manager per model. Just add the custom model manager and this property to a model::
+
+   report_builder_model_manager = on_site #reference to custom model manager to use for a model
+
 Export to Report action is disabled by default. To enable set::
     
     REPORT_BUILDER_GLOBAL_EXPORT = True

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -13,9 +13,18 @@ from dateutil import parser
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
+
 class Report(models.Model):
     """ A saved report with queryset and descriptive fields
     """
+    def _get_model_manager(self):
+        """ Get  manager from settings else use objects
+        """
+        model_manager = 'objects'
+        if getattr(settings, 'REPORT_BUILDER_MODEL_MANAGER', False):
+            model_manager = settings.REPORT_BUILDER_MODEL_MANAGER
+        return model_manager
+
     def _get_allowed_models():
         models = ContentType.objects.all()
         if getattr(settings, 'REPORT_BUILDER_INCLUDE', False):
@@ -36,8 +45,7 @@ class Report(models.Model):
     starred = models.ManyToManyField(AUTH_USER_MODEL, blank=True,
                                      help_text="These users have starred this report for easy reference.",
                                      related_name="report_starred_set")
-    
-    
+
     def save(self, *args, **kwargs):
         if not self.id:
             unique_slugify(self, self.name)
@@ -63,7 +71,14 @@ class Report(models.Model):
         report = self
         model_class = report.root_model.model_class()
         message= ""
-        objects = model_class.objects.all()
+
+        # Check for report_builder_model_manger property on the model
+        if getattr(model_class, 'report_builder_model_manager', False):
+            objects = getattr(model_class, 'report_builder_model_manager').all()
+        else:
+            # Get global model manager
+            manager = report._get_model_manager()
+            objects = getattr(model_class, manager).all()
 
         # Filters
         # NOTE: group all the filters together into one in order to avoid 

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -13,7 +13,7 @@ except ImportError:
 
 class UtilityFunctionTests(TestCase):
     def setUp(self):
-        self.report_ct = ContentType.objects.get_for_model(Report) 
+        self.report_ct = ContentType.objects.get_for_model(Report)
         self.report = Report.objects.create(
             name="foo report",
             root_model=self.report_ct)
@@ -67,6 +67,24 @@ class UtilityFunctionTests(TestCase):
         # Not a very complete test - only tests one type of filter
         result = filter_property(self.filter_field, 'spam')
         self.assertTrue(result)
+
+    def test_custom_global_model_manager(self):
+        #test for custom global model manager
+        if getattr(settings, 'REPORT_BUILDER_MODEL_MANAGER', False):
+            self.assertEquals(self.report._get_model_manager(), settings.REPORT_BUILDER_MODEL_MANAGER)
+
+    def test_custom_model_manager(self):
+        #test for custom model manager
+        if getattr(self.report.root_model.model_class(), 'report_builder_model_manager', True):
+            #change setup to use actual field and value
+            self.filter_field.field = 'name'
+            self.filter_field.filter_value = 'foo'
+            self.filter_field.save()
+            #coverage of get_query
+            objects, message = self.report.get_query()
+            #expect custom manager to return correct object with filters
+            self.assertEquals(objects[0], self.report)
+
 
 class ViewTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
...REPORT_BUILDER_MODEL_MANAGER and/or setting custom model manager per model using report_builder_model_manager property.

Note: 
Added two test one for the global manager settings and another for per model custom manager. For the per model test, I wanted to ensure coverage of my changes to get_query on the Report model, so I over-road the test setup filter fields so the test could make it through. Assumes a custom model manager would not affect the FilterField. I only assert when the model manager settings are used.

Also, I updated the quickstart doc to reflect these new settings. 
