### PR TITLE
KeyError when using TimeZoneField

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -220,7 +220,7 @@ class DisplayField(models.Model):
         except:
             model_field = None
         if model_field and model_field.choices:
-            return model_field.choices
+            return ((model_field.get_prep_value(key), val) for key, val in model_field.choices)
 
     @property
     def choices_dict(self):


### PR DESCRIPTION
Hello!

I'm loving this report builder for giving people self-service exports. I just hit an issue I haven't been able to sort out:

Whenever a `TimeZoneField` (version 1.0, from https://github.com/mfogel/django-timezone-field) I hit a `KeyError` in the report output (preview and full xlsx, naturally)

Here is the relevant tail of the stack trace:

```
  File ".../report_builder/views.py", line 643, in ajax_preview
    objects_list, message = report_to_list(report, request.user, preview=True)

  File ".../report_builder/views.py", line 575, in report_to_list
    row[position-1] = unicode(choice_list[row[position-1]])

KeyError: u'Africa/Abidjan'
```

I don't fully grok the code at that location. I have confirmed that _any_ non-null value triggers the error.

The choices for the `TimeZoneField` appears to be constructed in a reasonable way at https://github.com/mfogel/django-timezone-field/blob/develop/timezone_field/fields.py#L36

``` python
    CHOICES = [(pytz.timezone(tz), tz) for tz in pytz.all_timezones]
```

Any help would be greatly appreciated. Thanks!

Kenn
