### PR TITLE
Add Bountysource badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ django-report-builder
 A GUI for Django ORM. Build custom queries and display results. Targets sys admins and capable end users who might 
 not be able to program or gain direct interactive shell access.
 
-[![Build Status](https://travis-ci.org/burke-software/django-report-builder.png?branch=master)](https://travis-ci.org/burke-software/django-report-builder)
+[![Build Status](https://travis-ci.org/burke-software/django-report-builder.png?branch=master)](https://travis-ci.org/burke-software/django-report-builder) [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=314767)](https://www.bountysource.com/trackers/314767-burke-software-django-report-builder?utm_source=314767&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 
 [Support development on gittip](www.gittip.com/bufke)
 


### PR DESCRIPTION
Because you have some open bounties, we thought you might want to display this badge in your README!
