### PR TITLE
Require a specific version of openpyxl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 django==1.7.5
-openpyxl
+openpyxl==2.1.5
 python-dateutil
 django-report-utils==0.3.1
 django-custom-field

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     install_requires=[
         'django>=1.7',
-        'openpyxl',
+        'openpyxl==2.1.5',
         'python-dateutil',
         'django-report-utils==0.3.1',
         'djangorestframework>=3.0.4',


### PR DESCRIPTION
Otherwise 2.2.0-b1 is installed from pypi and there appear to be issues:

    ...                                                                          
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/report_builder/views.py", line 112, in get report_id, request.user.pk, to_response=True) 
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/report_builder/views.py", line 88, in process_report objects_list, title, header, widths)
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/report_utils/mixins.py", line 132, in list_to_xlsx_response wb = self.list_to_workbook(data, title, header, widths)
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/report_utils/mixins.py", line 110, in list_to_workbook self.build_sheet(data, ws, header=header, widths=widths)
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/report_utils/mixins.py", line 56, in build_sheet cell.style = cell.style.copy(
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/openpyxl/styles/styleable.py", line 107, in style protection=self.protection
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/openpyxl/styles/__init__.py", line 42, in __init__ self._font = font
    File "~/.virtualenvs/fc/local/lib/python2.7/site-packages/openpyxl/descriptors/base.py", line 35, in __set__ raise TypeError('expected ' + str(self.expected_type))
    TypeError: expected <class 'openpyxl.styles.fonts.Font'>                     
