### PR TITLE
Support filtering of date fields by "Is null"

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -348,7 +348,7 @@ class FilterField(models.Model):
         if self.filter_type == "range":
             if self.filter_value2 in [None, ""]:
                 raise ValidationError('Range filters must have two values')
-        if self.field_type == "DateField":
+        if self.field_type == "DateField" and self.filter_type != "isnull":
             date_form = forms.DateField()
             date_value = parser.parse(self.filter_value).date()
             date_form.clean(date_value)


### PR DESCRIPTION
When filtering date fields by "Is null", avoid trying to parse the date. Attempting to parse the date causes dateutil to raise a ValueError.