### PR TITLE
Adding the ability to disable the static frontend

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -63,6 +63,14 @@ Advantages of this option
 - Download the last report that was run instead of regenerating
 - Nicer status messages about report status
 
+### Turn off front-end
+
+If you're developing your own front-end then you would need the ability to disable the front-end that comes with this package. To disable the built-in front-end:
+
+    REPORT_BUILDER_FRONTEND = False
+
+By default the front-end is turned on.
+
 **Installation**
 
 1. Set up Celery

--- a/report_builder/urls.py
+++ b/report_builder/urls.py
@@ -25,7 +25,7 @@ urlpatterns = patterns('',
     url('^report/(?P<pk>\d+)/$', views.ReportSPAView.as_view(), name="report_update_view"),
 )
 
-if not hasattr(settings, 'REPORT_BUILDER_FRONTEND_OFF') or not settings.REPORT_BUILDER_FRONTEND_OFF:
+if not hasattr(settings, 'REPORT_BUILDER_FRONTEND') or settings.REPORT_BUILDER_FRONTEND:
     urlpatterns += patterns('',
         url(r'^',  staff_member_required(views.ReportSPAView.as_view()), name="report_builder"),
     )

--- a/report_builder/urls.py
+++ b/report_builder/urls.py
@@ -3,7 +3,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from rest_framework import routers
 from . import views
 from .api import views as api_views
-
+from django.conf import settings
 
 router = routers.DefaultRouter()
 router.register(r'reports', api_views.ReportViewSet)
@@ -23,5 +23,9 @@ urlpatterns = patterns('',
     url(r'^api/fields',  staff_member_required(api_views.FieldsView.as_view()), name="fields"),
     url(r'^api/report/(?P<report_id>\w+)/generate/',  staff_member_required(api_views.GenerateReport.as_view()), name="generate_report"),
     url('^report/(?P<pk>\d+)/$', views.ReportSPAView.as_view(), name="report_update_view"),
-    url(r'^',  staff_member_required(views.ReportSPAView.as_view()), name="report_builder"),
 )
+
+if not hasattr(settings, 'REPORT_BUILDER_FRONTEND_OFF') or not settings.REPORT_BUILDER_FRONTEND_OFF:
+    urlpatterns += patterns('',
+        url(r'^',  staff_member_required(views.ReportSPAView.as_view()), name="report_builder"),
+    )


### PR DESCRIPTION
I needed the ability to remove the static front-end for the django-rest-framework. I tried to find it in the codebase, but couldn't. If this is not the correct solution - could you help me figure out the correct solution.

Thanks!