### PR TITLE
Django's cached property decorator as a property

### DIFF
--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -4,6 +4,7 @@ from rest_framework import viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
+from django.utils.functional import cached_property
 from .serializers import (
     ReportNestedSerializer, ReportSerializer, FormatSerializer,
     FilterFieldSerializer)
@@ -128,7 +129,7 @@ class FieldsView(RelatedFieldsView):
                 extra_fields = extra
             for field in extra_fields:
                 field_attr = getattr(self.model_class, field, None)
-                if isinstance(field_attr, property):
+                if isinstance(field_attr, property) or isinstance(field_attr, cached_property):
                     result += [{
                         'name': field,
                         'field': field,


### PR DESCRIPTION
I have been using this in my own fork of django-report-builder, but I thought the community would benefit from this. Django has a @cached_property decorator that's commonly used. I wanted to add as currently the @cached_property does not appear when you put it in the extra initializer. 

I wasn't completely sure how you'd want to handle this. I took a crack at it, and would love your feedback here.