### PR TITLE
Adding way to include/exclude specific models by specifying app_label

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,8 +18,13 @@ See setup.py for full requirements list.
 
 ### Include and exclude fields and models
 
-    REPORT_BUILDER_INCLUDE = []
-    REPORT_BUILDER_EXCLUDE = ['user'] # Allow all models except User to be accessed
+To include a model you've to specify with app your models belong to. If your 'user' model is in the app 'hr' then you can do the following to include it:
+
+    REPORT_BUILDER_INCLUDE = ['hr.user'] # Allow only the model user to be accessed
+
+The same reasoning also applies to exclude models. If your 'account' model is in the app 'finance' then you can do the following to exclude it:
+
+    REPORT_BUILDER_EXCLUDE = ['finance.account'] # Allow all models except account to be accessed
 
 ### Per model settings
 

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -22,9 +22,26 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 def get_allowed_models():
     models = ContentType.objects.all()
     if getattr(settings, 'REPORT_BUILDER_INCLUDE', False):
-        models = models.filter(model__in=settings.REPORT_BUILDER_INCLUDE)
+        all_model_names = []
+        additional_models = []
+        for element in settings.REPORT_BUILDER_INCLUDE:
+            split_element = element.split('.')
+            if len(split_element) == 2:
+                additional_models.append(models.filter(app_label=split_element[0], model=split_element[1]))
+            else:
+                all_model_names.append(element)
+        models = models.filter(model__in=all_model_names)
+        for additional_model in additional_models:
+            models = models | additional_model
     if getattr(settings, 'REPORT_BUILDER_EXCLUDE', False):
-        models = models.exclude(model__in=settings.REPORT_BUILDER_EXCLUDE)
+        all_model_names = []
+        for element in settings.REPORT_BUILDER_EXCLUDE:
+            split_element = element.split('.')
+            if len(split_element) == 2:
+                models = models.exclude(app_label=split_element[0], model=split_element[1])
+            else:
+                all_model_names.append(element)
+        models = models.exclude(model__in=all_model_names)
     return models
 
 

--- a/report_builder_demo/demo_second_app/admin.py
+++ b/report_builder_demo/demo_second_app/admin.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from custom_field.custom_field import CustomFieldAdmin
+from .models import Bar
+
+
+@admin.register(Bar)
+class BarAdmin(CustomFieldAdmin, admin.ModelAdmin):
+    pass

--- a/report_builder_demo/demo_second_app/models.py
+++ b/report_builder_demo/demo_second_app/models.py
@@ -1,0 +1,13 @@
+from django.db import models
+from custom_field.custom_field import CustomFieldModel
+
+
+class Bar(CustomFieldModel, models.Model):
+    char_field = models.CharField(max_length=50, blank=True)
+
+    @property
+    def i_want_char_field(self):
+        return 'lol no'
+
+    class ReportBuilder:
+        extra = ('i_want_char_field',)

--- a/report_builder_demo/settings.py
+++ b/report_builder_demo/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'rest_framework',
     'report_builder_demo.demo_models',
+    'report_builder_demo.demo_second_app',
     'report_builder',
     'report_utils',
     'custom_field',


### PR DESCRIPTION
The two last pull requests I sent were conflicting. Sorry I had to send a new one:

The project I am working on has a large code-base and thus has models which have the same name. The current method only filters the models by name, and not by the app they are in. This is more for django applications with multiple models.

I needed to add the ability to specify which app the particular model belongs to. I have tested it and I don't think this particular method breaks anything. The simple change would be the ability to add demo_models.foo rather than foo. I kept it backwards compatible and so if there's foo it would still work.

Let me know if you've any feedback. I would be happy to add/edit this particular solution.