### PR TITLE
Django's cached property decorator as a property

### DIFF
--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -129,7 +129,7 @@ class FieldsView(RelatedFieldsView):
                 extra_fields = extra
             for field in extra_fields:
                 field_attr = getattr(self.model_class, field, None)
-                if isinstance(field_attr, property) or isinstance(field_attr, cached_property):
+                if isinstance(field_attr, (property, cached_property)):
                     result += [{
                         'name': field,
                         'field': field,

--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
+from django.utils.functional import cached_property
 from rest_framework import viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -128,7 +129,7 @@ class FieldsView(RelatedFieldsView):
                 extra_fields = extra
             for field in extra_fields:
                 field_attr = getattr(self.model_class, field, None)
-                if isinstance(field_attr, property):
+                if isinstance(field_attr, property) or isinstance(field_attr, cached_property):
                     result += [{
                         'name': field,
                         'field': field,

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.utils.safestring import mark_safe
+from django.utils.functional import cached_property
 from django.db import models
 from django.db.models import Avg, Min, Max, Count, Sum
 from django.db.models.fields import FieldDoesNotExist
@@ -100,7 +101,7 @@ class Report(models.Model):
             pass
         # Is it a property?
         field_attr = getattr(model, field_name, None)
-        if isinstance(field_attr, property):
+        if isinstance(field_attr, property) or isinstance(field_attr, cached_property):
             return "Property"
         # Is it a custom field?
         try:

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -101,7 +101,7 @@ class Report(models.Model):
             pass
         # Is it a property?
         field_attr = getattr(model, field_name, None)
-        if isinstance(field_attr, property) or isinstance(field_attr, cached_property):
+        if isinstance(field_attr, (property, cached_property)):
             return "Property"
         # Is it a custom field?
         try:

--- a/report_builder_demo/demo_models/models.py
+++ b/report_builder_demo/demo_models/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.utils.functional import cached_property
 from custom_field.custom_field import CustomFieldModel
 
 
@@ -23,8 +24,12 @@ class Bar(CustomFieldModel, models.Model):
     def i_want_char_field(self):
         return 'lol no'
 
+    @cached_property
+    def i_need_char_field(self):
+        return 'lol yes'
+
     class ReportBuilder:
-        extra = ('i_want_char_field',)
+        extra = ('i_want_char_field', 'i_need_char_field',)
 
 
 class Place(models.Model):


### PR DESCRIPTION
The two last pull requests I sent were conflicting. Sorry I had to send a new one:

I have been using this in my own fork of django-report-builder, but I thought the community would benefit from this. Django has a @cached_property decorator that's commonly used. I wanted to add as currently the @cached_property does not appear when you put it in the extra initializer.

I wasn't completely sure how you'd want to handle this. I took a crack at it, and would love your feedback here.