### PR TITLE
Adding distinction between a filter and a display field

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,6 +43,15 @@ Moreover, we have added functionality to set fields to display by default. This 
 
 The `defaults` field would usually be a subset of the `fields`. The idea is that you would have a `is_defualt` field on the JSON-frontend that would allow you to recognize that this is a default value on your own front-end.
 
+You can also mark which fields you would like to set as filters for the JSON end-point. This is currently not valuable to the front-end that django-report-builder comes with, but if you have your own front-end then you could utilize this information.
+
+This filter is purely cosmetic, and not used in any way internally in the configuration of report-builder. This is not a security measure.
+
+    class ReportBuilder:
+        filters = () # Lists or tuple of filters
+
+The distinction here is only created if you want to differentiate display fields and filters. It is possible by this to create a distinction between a display field and a field the user can filter by.
+
 ### Custom model manager for all models
 
     REPORT_BUILDER_MODEL_MANAGER = 'on_site' #name of custom model manager to use on all models

--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -92,11 +92,13 @@ class FieldsView(RelatedFieldsView):
             self.path_verbose,)
         result = []
         fields = None
+        filters = None
         extra = None
         defaults = None
         meta = getattr(self.model_class, 'ReportBuilder', None)
         if meta is not None:
             fields = getattr(meta, 'fields', None)
+            filters = getattr(meta, 'filters', None)
             exclude = getattr(meta, 'exclude', None)
             extra = getattr(meta, 'extra', None)
             defaults = getattr(meta, 'defaults', None)
@@ -123,6 +125,7 @@ class FieldsView(RelatedFieldsView):
                 'field_type': new_field.get_internal_type(),
                 'is_default': True if defaults is None or new_field.name in defaults else False,
                 'field_choices': new_field.choices,
+                'can_filter': True if filters is None or new_field.name in filters else False,
                 'path': field_data['path'],
                 'path_verbose': field_data['path_verbose'],
                 'help_text': new_field.help_text,
@@ -144,6 +147,7 @@ class FieldsView(RelatedFieldsView):
                         'field_verbose': field,
                         'field_type': 'Property',
                         'field_choices': None,
+                        'can_filter': True if filters is None or new_field.name in filters else False,
                         'path': field_data['path'],
                         'path_verbose': field_data['path_verbose'],
                         'is_default': True if defaults is None or new_field.name in defaults else False,
@@ -161,6 +165,7 @@ class FieldsView(RelatedFieldsView):
                     'field_verbose': field.name,
                     'field_type': 'Custom Field',
                     'field_choices': new_field.choices,
+                    'can_filter': True if filters is None or new_field.name in filters else False,
                     'path': field_data['path'],
                     'path_verbose': field_data['path_verbose'],
                     'is_default': True if defaults is None or new_field.name in defaults else False,

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -155,6 +155,14 @@ class ReportBuilderTests(TestCase):
         self.assertContains(response, 'field_choices')
         self.assertContains(response, '[["CH","CHECK"],["MA","CHECKMATE"]]')
 
+    def test_report_builder_can_filter(self):
+        ct = ContentType.objects.get(model="bar")
+        response = self.client.post(
+            '/report_builder/api/fields/',
+            {"model": ct.id, "path": "", "path_verbose": "", "field": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'can_filter')
+
 
 class ReportTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
In my current project I needed to add the ability to differentiate between fields to filter by and fields to display. I will not touch the front-end for report-builder as I am not sure if this is a design choice you want to enforce, but I added this as an extra feature people could utilize if they are defining their own front-end.

The addition here is to introduce a `filters` field that the user can define in the `ReportBuilder` class that is defined in their model. Then the JSON end-point in `/fields/` would have an extra field called `is_filter` that would be True or False. If the `filters` is not defined then by default all fields in `is_filter` would be set to True. 

Let me know of your thoughts!

This is for issue #166.

If merged alongside the `is_defaults` pull request then I will improve the documentation once they both get added in.