### PR TITLE
Adding ability to have default fields

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,6 +36,13 @@ Note you can add properties in a similair way as Django admin.
 In previous versions of django-report-builder all properties were included by default.
 They must now be explicitly included.
 
+Moreover, we have added functionality to set fields to display by default. This is currently not valuable to the front-end that django-report-builder comes with, but if you have your own front-end then you could utilize this information. The aim is that when you select the model you want to filter on these fields would be selected as display defaults automatically.
+
+    class ReportBuilder:
+        defaults = () # Lists or tuple of defaults
+
+The `defaults` field would usually be a subset of the `fields`. The idea is that you would have a `is_defualt` field on the JSON-frontend that would allow you to recognize that this is a default value on your own front-end.
+
 ### Custom model manager for all models
 
     REPORT_BUILDER_MODEL_MANAGER = 'on_site' #name of custom model manager to use on all models

--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -88,11 +88,13 @@ class FieldsView(RelatedFieldsView):
         result = []
         fields = None
         extra = None
+        defaults = None
         meta = getattr(self.model_class, 'ReportBuilder', None)
         if meta is not None:
             fields = getattr(meta, 'fields', None)
             exclude = getattr(meta, 'exclude', None)
             extra = getattr(meta, 'extra', None)
+            defaults = getattr(meta, 'defaults', None)
             if fields is not None:
                 fields = list(fields)
                 for field in copy.copy(field_data['fields']):
@@ -114,6 +116,7 @@ class FieldsView(RelatedFieldsView):
                 'field': new_field.name,
                 'field_verbose': verbose_name,
                 'field_type': new_field.get_internal_type(),
+                'is_default': True if defaults is None or new_field.name in defaults else False,
                 'path': field_data['path'],
                 'path_verbose': field_data['path_verbose'],
                 'help_text': new_field.help_text,
@@ -136,6 +139,7 @@ class FieldsView(RelatedFieldsView):
                         'field_type': 'Property',
                         'path': field_data['path'],
                         'path_verbose': field_data['path_verbose'],
+                        'is_default': True if defaults is None or new_field.name in defaults else False,
                         'help_text': 'Adding this property will '
                         'significantly increase the time it takes to run a '
                         'report.'
@@ -151,6 +155,7 @@ class FieldsView(RelatedFieldsView):
                     'field_type': 'Custom Field',
                     'path': field_data['path'],
                     'path_verbose': field_data['path_verbose'],
+                    'is_default': True if defaults is None or new_field.name in defaults else False,
                     'help_text': 'This is a custom field.',
                 }]
         return Response(result)

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -137,6 +137,14 @@ class ReportBuilderTests(TestCase):
         self.assertContains(response, 'char_field')
         self.assertContains(response, 'i_want_char_field')
 
+    def test_report_builder_is_default(self):
+        ct = ContentType.objects.get(model="bar")
+        response = self.client.post(
+            '/report_builder/api/fields/',
+            {"model": ct.id, "path": "", "path_verbose": "", "field": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'is_default')
+
 
 class ReportTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
In my current project I needed to add the ability to add default fields that are displayed. Similar to the pull request #167 I haven't changed anything in the front-end. This is purely an addition to the JSON-endpoint and the configuration that the user is able to add.

The idea with default fields is that we wanted to automatically add certain fields when you select a particular model as displays. Currently the fields that are displayed are empty, and we wanted some way of telling the front-end what the default fields are rather than hard-coding them.

The addition here is to introduce a `defaults` field that the user can define in the ReportBuilder class that is defined in their model. Then the JSON end-point in `/fields/` would have an extra field called `is_default` that would be True or False. If the `defaults` is not defined then by default all fields in `is_default` would be set to True.

Let me know of your thoughts!

If merged alongside the `can_filter` pull request then I will improve the documentation once they both get added in. In addition, (if you'd want) I would be happy to add this into the front-end in the future.