### PR TITLE
Adding ability to see choices on the fields endpoint

### DIFF
--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -115,6 +115,7 @@ class FieldsView(RelatedFieldsView):
                 'field': new_field.name,
                 'field_verbose': verbose_name,
                 'field_type': new_field.get_internal_type(),
+                'field_choices': new_field.choices,
                 'path': field_data['path'],
                 'path_verbose': field_data['path_verbose'],
                 'help_text': new_field.help_text,
@@ -135,6 +136,7 @@ class FieldsView(RelatedFieldsView):
                         'field': field,
                         'field_verbose': field,
                         'field_type': 'Property',
+                        'field_choices': None,
                         'path': field_data['path'],
                         'path_verbose': field_data['path_verbose'],
                         'help_text': 'Adding this property will '
@@ -150,6 +152,7 @@ class FieldsView(RelatedFieldsView):
                     'field': field.name,
                     'field_verbose': field.name,
                     'field_type': 'Custom Field',
+                    'field_choices': new_field.choices,
                     'path': field_data['path'],
                     'path_verbose': field_data['path_verbose'],
                     'help_text': 'This is a custom field.',

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -138,6 +138,15 @@ class ReportBuilderTests(TestCase):
         self.assertContains(response, 'i_want_char_field')
         self.assertContains(response, 'i_need_char_field')
 
+    def test_report_builder_choices(self):
+        ct = ContentType.objects.get(model="bar")
+        response = self.client.post(
+            '/report_builder/api/fields/',
+            {"model": ct.id, "path": "", "path_verbose": "", "field": ""})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'field_choices')
+        self.assertContains(response, '[["CH","CHECK"],["MA","CHECKMATE"]]')
+
 
 class ReportTests(TestCase):
     def setUp(self):

--- a/report_builder_demo/demo_models/migrations/0005_auto_20150622_1840.py
+++ b/report_builder_demo/demo_models/migrations/0005_auto_20150622_1840.py
@@ -20,9 +20,6 @@ class Migration(migrations.Migration):
                 ('age', models.IntegerField(default=None, null=True, blank=True)),
                 ('color', models.CharField(default=b'', max_length=1, blank=True, choices=[(b'R', b'Red'), (b'G', b'Green'), (b'B', b'Blue')])),
             ],
-            options={
-            },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='Person',
@@ -31,14 +28,15 @@ class Migration(migrations.Migration):
                 ('first_name', models.CharField(max_length=50)),
                 ('last_name', models.CharField(max_length=50)),
             ],
-            options={
-            },
-            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name='bar',
+            name='check_mate_status',
+            field=models.CharField(default=b'CH', max_length=2, choices=[(b'CH', b'CHECK'), (b'MA', b'CHECKMATE')]),
         ),
         migrations.AddField(
             model_name='child',
             name='parent',
             field=models.ForeignKey(related_name='children', to='demo_models.Person'),
-            preserve_default=True,
         ),
     ]

--- a/report_builder_demo/demo_models/models.py
+++ b/report_builder_demo/demo_models/models.py
@@ -20,6 +20,19 @@ class Bar(CustomFieldModel, models.Model):
     char_field = models.CharField(max_length=50, blank=True)
     foos = models.ManyToManyField(Foo, blank=True)
 
+    CHECK = 'CH'
+    MATE = 'MA'
+    CHESS_CHOICES = (
+        (CHECK, 'CHECK'),
+        (MATE, 'CHECKMATE'),
+    )
+
+    check_mate_status = models.CharField(
+        max_length=2,
+        choices=CHESS_CHOICES,
+        default=CHECK
+    )
+
     @property
     def i_want_char_field(self):
         return 'lol no'


### PR DESCRIPTION
Relates to issue #165. 

If you have a field in your model that you define choices for then the django-report-builder backend should provide that as a field in the endpoint. In this pull request I added that as a functionality. 

Just a one line addition in the `views.py` file, and adding additional tests.