### PR TITLE
Adding feature to allow reports to be emailed

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,6 +70,25 @@ Advantages of this option
 - Download the last report that was run instead of regenerating
 - Nicer status messages about report status
 
+### Email notification when file is uploaded
+
+The reports are emailed to the current user rather than generated and then downloaded. This is if you have reports that take a while to generate or if you'd prefer your users to be emailed.
+
+The current front-end simply downloads the report right away, and so this is a feature you'll have to enable on the front-end yourself (or the package will support it in the future).
+
+    REPORT_BUILDER_EMAIL_NOTIFICATION = True
+
+This uses the default django mail implementation. The code checks for either `EMAIL_BACKEND` or `EMAIL_HOST` to be defined in the `settings.py` file. You should also define `DEFAULT_FROM_EMAIL`.
+
+You're also able to stylize the templates according to your needs. To enable the reports:
+
+    REPORT_BUILDER_EMAIL_NOTIFICATION = True
+    REPORT_BUILDER_EMAIL_SUBJECT = ""
+
+This package uses Django-Templates for its email templates. The report path it uses is `email/email_report.html`, and you're able to overwrite this in your own django application.
+
+The `{{report}}` element is what would be replaced with the report URL, and the `{{name}}`. The field `REPORT_BUILDER_EMAIL_SUBJECT` will be defaulted to 'Report is ready' if missing.
+
 ### Turn off front-end
 
 If you're developing your own front-end then you would need the ability to disable the front-end that comes with this package. To disable the built-in front-end:

--- a/report_builder/templates/email/email_report.html
+++ b/report_builder/templates/email/email_report.html
@@ -1,0 +1,3 @@
+<p>Hello {{name}},</p>
+<br>
+<p>The report is <a href='{{report}}'>here</u></p>

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -1,7 +1,9 @@
 from django.contrib.contenttypes.models import ContentType
+from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from .models import Report, DisplayField, FilterField, Format
+from .views import email_report
 from report_builder_demo.demo_models.models import Bar, Place, Restaurant, Waiter, Person, Child
 from django.conf import settings
 from report_utils.model_introspection import (
@@ -691,3 +693,29 @@ class ReportTests(TestCase):
     def test_admin(self):
         response = self.client.get('/admin/report_builder/report/')
         self.assertEqual(response.status_code, 200)
+
+
+class ViewTests(TestCase):
+    def test_email_report_without_template(self):
+        settings.REPORT_BUILDER_EMAIL_NOTIFICATION = True
+        email_subject = getattr(settings, 'REPORT_BUILDER_EMAIL_SUBJECT', False) or "Report is ready"
+        user = User.objects.get_or_create(username='example', email='to@example.com')[0]
+        email_report(email_subject, user)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, email_subject)
+        settings.REPORT_BUILDER_EMAIL_NOTIFICATION = None
+        mail.outbox = []
+
+    def test_email_report_with_template(self):
+        settings.REPORT_BUILDER_EMAIL_NOTIFICATION = True
+        report_url = 'http://fakeurl.com/fakestuffs'
+        username = 'example'
+        email_subject = getattr(settings, 'REPORT_BUILDER_EMAIL_SUBJECT', False) or "Report is ready"
+        user = User.objects.get_or_create(username=username, email='to@example.com')[0]
+        email_report(report_url, user)
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].subject, email_subject)
+        self.assertEqual(mail.outbox[0].alternatives[0][0], "<p>Hello {0},</p>\n<br>\n<p>The report is <a href='{1}'>here</u></p>".format(username, report_url))
+        settings.REPORT_BUILDER_EMAIL_NOTIFICATION = None
+        settings.REPORT_BUILDER_EMAIL_TEMPLATE = None
+        mail.outbox = []

--- a/report_builder_demo/settings.py
+++ b/report_builder_demo/settings.py
@@ -99,6 +99,7 @@ CELERY_RESULT_BACKEND = BROKER_URL
 
 REPORT_BUILDER_ASYNC_REPORT = True
 REPORT_BUILDER_GLOBAL_EXPORT = True
+REPORT_BUILDER_EMAIL_NOTIFICATION = False
 
 if 'test' in sys.argv:
     DATABASES['default'] = {'ENGINE': 'django.db.backends.sqlite3'}


### PR DESCRIPTION
On the project I am working on we wanted to add the ability to email the user rather than generate it and get a download (either asynchronously or synchronously). I've taken a first try at implementing this into django-report-builder. I added a `email_report` report to `views.py` that is called if the user sets the setting `REPORT_BUILDER_EMAIL_NOTIFICATION` to `True` in `settings.py`.

By default the email is sent to the current user's `user.email`. I have already defined the subject headers, and the body for the default email that is sent. In addition, I also attempted to add templating, but tried to be as abstract as possible and as less reliant on other templating libraries as possible. 

The templating, as I implemented it, is the user specifying a string with HTML in the settings file: `REPORT_BUILDER_EMAIL_TEMPLATE`. We're going to be implementing it using django-dbtemplates, but I didn't want to force other django projects to use that.

I would love some feedback on the code I've already implemented, and things I should improve on or packages I should utilize. I'll improve them, and would love this to be merged at some point.