### PR TITLE
Adding include/exclude configuration parameters for relatedfieldviews

### DIFF
--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
+from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -62,6 +63,21 @@ class RelatedFieldsView(GetFieldsMixin, APIView):
             self.path_verbose,)
         result = []
         for new_field in new_fields:
+            included_model = True
+            model_information = new_field.related_model._meta.app_label + "." + new_field.related_model._meta.model_name
+            if getattr(settings, 'REPORT_BUILDER_INCLUDE', False):
+                includes = getattr(settings, 'REPORT_BUILDER_INCLUDE')
+                # If it is not included as 'foo' and not as 'demo_models.foo'
+                if (new_field.related_model._meta.model_name not in includes and
+                    model_information not in includes):
+                    included_model = False
+            if getattr(settings, 'REPORT_BUILDER_EXCLUDE', False):
+                excludes = getattr(settings, 'REPORT_BUILDER_EXCLUDE')
+                # If it is excluded as 'foo' and as 'demo_models.foo'
+                if (new_field.related_model._meta.model_name in excludes or
+                    model_information in excludes):
+                    included_model = False
+
             verbose_name = getattr(new_field, 'verbose_name', None)
             if verbose_name == None:
                 verbose_name = new_field.get_accessor_name()
@@ -71,6 +87,9 @@ class RelatedFieldsView(GetFieldsMixin, APIView):
                 'path': path,
                 'help_text': getattr(new_field, 'help_text', ''),
                 'model_id': model_ct.id,
+                'parent_model_name': new_field.related_model._meta.model_name,
+                'parent_model_app_label': new_field.related_model._meta.app_label,
+                'included_model': included_model,
             }]
         return Response(result)
 


### PR DESCRIPTION
While working with the endpoint `related_fields` we realized that this endpoint doesn't give an indication or consideration to the models that are defined in `REPORT_BUILDER_INCLUDE` or `REPORT_BUILDER_EXCLUDE`. We wanted to add some functionality to make it really easy to figure out what model/app it belongs to, and if it is something that is either included in the `INCLUDE` or `EXCLUDE` configuration. 

We wanted this to be backwards compatible so it wouldn't interfere with the current front_end, and so we added three new fields to the endpoint. `parent_model_name`, `parent_model_app_label`, and `included_model`. The `included_model` is the most important here because it gives an indication of if it is a model that we configured to be accessible in our configuration variables. 

I would love feedback/opinions on this. Something I think would be a good addition to report-builder. We needed it to give a clear indication to the front-end that this related_field needs to be considered. 