### PR TITLE
Test on all django versions on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python:
   - "2.7"
   - "3.4"
-# command to install dependencies
-install: "pip install -r requirements.txt"
-# command to run tests
+env:
+  matrix:
+    - DJANGO_VERSION="django>=1.7,<1.8"
+    - DJANGO_VERSION="django>=1.8,<1.9"
+install:
+  - pip install -e . -r requirements.txt $DJANGO_VERSION
 script: python manage.py test
 sudo: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt django==1.8
 ADD . /code/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django==1.8
 openpyxl==2.2.1
 python-dateutil
 django-report-utils==0.3.10


### PR DESCRIPTION
The setup.py specifies that Django should >=1.7, which means 1.7 or 1.8. So travis CI should test both versions.