### PR TITLE
Remove package dependencies from requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
-RUN pip install -r requirements.txt django==1.8
+ADD setup.py /code/
+RUN pip install -e . -r requirements.txt django==1.8
 ADD . /code/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-openpyxl==2.2.1
-python-dateutil
-django-report-utils==0.3.10
 django-custom-field==2.5
-djangorestframework==3.1.2
 psycopg2
 django-extensions
 Werkzeug


### PR DESCRIPTION
By installing the package itself, we get the dependencies it specifies. This means we don't have to keep the requirements.txt in sync with setup.py. Instead we will get the same requirements that anyone else would when they install, for testing.