### PR TITLE
Seperate celery into seperate container in dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ pip-log.txt
 .mr.developer.cfg
 
 .ropeproject
+report_files
+media

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ redis:
   image: redis
 web:
   build: .
-  command: ./run.sh
+  command: python manage.py runserver_plus 0.0.0.0:8000
   volumes:
     - .:/code
     #- ../django-report-utils/report_utils:/usr/local/lib/python3.4/site-packages/report_utils
@@ -14,3 +14,13 @@ web:
   links:
     - db
     - redis
+celery:
+  build: .
+  command: celery -A report_builder_demo worker -l info
+  links:
+    - db
+    - redis
+  environment:
+    C_FORCE_ROOT: true
+  volumes:
+    - .:/code

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-export C_FORCE_ROOT="true"
-celery -A report_builder_demo worker -l info&
-python manage.py runserver_plus 0.0.0.0:8000


### PR DESCRIPTION
By moving celery into its own container, we get better debugging in docker-compose, by seperating our the logs. Also it is a bit clearer, since we remove a file and the commands are more explicit in the docker-compose.yml