### PR TITLE
Adding include/exclude configuration parameters for relatedfieldviews

### DIFF
--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
+from django.conf import settings
 from rest_framework import viewsets
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -64,6 +65,28 @@ class RelatedFieldsView(GetFieldsMixin, APIView):
             self.path_verbose,)
         result = []
         for new_field in new_fields:
+            included_model = True
+            split_name = new_field.name.split(':')
+            if len(split_name) == 1:
+                split_name.append('')
+                split_name[1] = split_name[0]
+                split_name[0] = False
+                model_information = split_name[1]
+            else:
+                model_information = split_name[0] + "." + split_name[1]
+            app_label = split_name[0]
+            model_name = split_name[1]
+            if getattr(settings, 'REPORT_BUILDER_INCLUDE', False):
+                includes = getattr(settings, 'REPORT_BUILDER_INCLUDE')
+                # If it is not included as 'foo' and not as 'demo_models.foo'
+                if (model_name not in includes and
+                        model_information not in includes):
+                    included_model = False
+            if getattr(settings, 'REPORT_BUILDER_EXCLUDE', False):
+                excludes = getattr(settings, 'REPORT_BUILDER_EXCLUDE')
+                # If it is excluded as 'foo' and as 'demo_models.foo'
+                if (model_name in excludes or model_information in excludes):
+                    included_model = False
             verbose_name = getattr(new_field, 'verbose_name', None)
             if verbose_name is None:
                 verbose_name = new_field.get_accessor_name()
@@ -73,6 +96,9 @@ class RelatedFieldsView(GetFieldsMixin, APIView):
                 'path': path,
                 'help_text': getattr(new_field, 'help_text', ''),
                 'model_id': model_ct.id,
+                'parent_model_name': model_name,
+                'parent_model_app_label': app_label,
+                'included_model': included_model,
             }]
         return Response(result)
 

--- a/report_builder/static/report_builder/controllers.js
+++ b/report_builder/static/report_builder/controllers.js
@@ -71,6 +71,11 @@ reportBuilderApp.controller('homeCtrl', function($scope, $routeParams, $location
       $scope.related_fields = [root_related_field]
       reportService.getRelatedFields(data).then(function(result) {
         root_related_field.related_fields = result;
+        var help_text = 'This model is included in report builder.';
+        if (result[0].included_model == false) {
+          help_text = 'This model is not included in report builder.';
+        }
+        $scope.help_text = help_text;
       });
       reportService.getFields(data).then(function(result) {
         $scope.fields = result;
@@ -161,8 +166,6 @@ reportBuilderApp.controller('LeftCtrl', function($scope, $routeParams, $mdSidena
 })
 
 reportBuilderApp.controller('FieldsCtrl', function($scope, $mdSidenav, reportService) {
-  $scope.help_text = '';
-
   $scope.load_fields = function(field) {
     data = {
       "model": field.model_id,
@@ -174,6 +177,14 @@ reportBuilderApp.controller('FieldsCtrl', function($scope, $mdSidenav, reportSer
     $scope.fields_header = field.verbose_name;
     reportService.getFields(data).then(function(result) {
       $scope.fields = result;
+    });
+    reportService.getRelatedFields(data).then(function(result) {
+      field.related_fields = result;
+      var help_text = 'This model is included in report builder.';
+      if (result[0].included_model == false) {
+        help_text = 'This model is not included in report builder.';
+      }
+      $scope.help_text = help_text;
     });
   }
 

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -156,6 +156,19 @@ class ReportBuilderTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'pizza')
 
+    def test_report_builder_fields_from_related_fields(self):
+        ct = ContentType.objects.get(model="place", app_label="demo_models")
+        response = self.client.post(
+            '/report_builder/api/related_fields/',
+            {"model": ct.id,
+             "path": "",
+             "path_verbose": "",
+             "field": "restaurant"})
+        self.assertContains(response, '"parent_model_name"')
+        self.assertContains(response, '"parent_model_app_label"')
+        self.assertContains(response, '"included_model"')
+        self.assertEqual(response.status_code, 200)
+
     def test_report_builder_exclude(self):
         ct = ContentType.objects.get(model="fooexclude", app_label="demo_models")
         response = self.client.post(


### PR DESCRIPTION
Second PR after #173. I realized there was an easier way to solve the issue rather than use `related_models` in Django. That didn't work out too well for all types of models.

While working with the endpoint `related_fields` we realized that this endpoint doesn't give an indication or consideration to the models that are defined in `REPORT_BUILDER_INCLUDE` or `REPORT_BUILDER_EXCLUDE`. We wanted to add some functionality to make it really easy to figure out what model/app it belongs to, and if it is something that is either included in the `INCLUDE` or `EXCLUDE` configuration. 

We wanted this to be backwards compatible so it wouldn't interfere with the current front_end, and so we added three new fields to the endpoint. `parent_model_name`, `parent_model_app_label`, and `included_model`. The `included_model` is the most important here because it gives an indication of if it is a model that we configured to be accessible in our configuration variables. 

I would love feedback/opinions on this. Something I think would be a good addition to report-builder. We needed it to give a clear indication to the front-end that this related_field needs to be considered. 