### PR TITLE
Add max and min annoation filters

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.utils.safestring import mark_safe
 from django.utils.functional import cached_property
 from django.db import models
-from django.db.models import Avg, Min, Max, Count, Sum
+from django.db.models import Avg, Min, Max, Count, Sum, F
 from django.db.models.fields import FieldDoesNotExist
 from report_builder.unique_slugify import unique_slugify
 from report_utils.model_introspection import get_model_from_path_string
@@ -138,11 +138,14 @@ class Report(models.Model):
         # unnecessary joins
         filters = {}
         excludes = {}
-        for filter_field in report.filterfield_set.all():
+        for filter_field in report.filterfield_set.order_by('position'):
             # exclude properties from standard ORM filtering
             if filter_field.field_type == "Property":
                 continue
             if filter_field.field_type == "Custom Field":
+                continue
+            if filter_field.filter_type in ('max', 'min'):
+                # Annotation-filters are handled below.
                 continue
 
             filter_string = str(filter_field.path + filter_field.field)
@@ -171,6 +174,21 @@ class Report(models.Model):
             objects = objects.filter(**filters)
         if excludes:
             objects = objects.exclude(**excludes)
+
+        # Apply annotation-filters after regular filters.
+
+        for filter_field in report.filterfield_set.order_by('position'):
+            if filter_field.filter_type in ('max', 'min'):
+                func = {'max': Max, 'min': Min}[filter_field.filter_type]
+                column_name = '{0}{1}__{2}'.format(
+                    filter_field.path,
+                    filter_field.field,
+                    filter_field.field_type
+                )
+                filter_string = filter_field.path + filter_field.field
+                annotate_args = {column_name: func(filter_string)}
+                filter_args = {column_name: F(filter_field.field)}
+                objects = objects.annotate(**annotate_args).filter(**filter_args)
 
         # Aggregates
         objects = self.add_aggregates(objects)
@@ -333,6 +351,8 @@ class FilterField(AbstractField):
             ('isnull', 'Is null'),
             ('regex', 'Regular Expression'),
             ('iregex', 'Reg. Exp. (case-insensitive)'),
+            ('max', 'Max (annotation-filter)'),
+            ('min', 'Min (annotation-filter)'),
         ),
         blank=True,
         default = 'icontains',
@@ -342,14 +362,18 @@ class FilterField(AbstractField):
     exclude = models.BooleanField(default=False)
 
     def clean(self):
-        if self.filter_type == "range":
-            if self.filter_value2 in [None, ""]:
-                raise ValidationError('Range filters must have two values')
-        if self.field_type == "DateField" and self.filter_type != "isnull":
+        if self.filter_type == 'range' and self.filter_value2 in [None, '']:
+            raise ValidationError('Range filters must have two values')
+
+        if self.filter_type in ('max', 'min'):
+            # These filter types ignore their value.
+            pass
+        elif self.field_type == 'DateField' and self.filter_type != 'isnull':
             date_form = forms.DateField()
             date_value = parser.parse(self.filter_value).date()
             date_form.clean(date_value)
             self.filter_value = str(date_value)
+
         return super(FilterField, self).clean()
 
     def get_choices(self, model, field_name):

--- a/report_builder/static/report_builder/partials/filter_renderer.html
+++ b/report_builder/static/report_builder/partials/filter_renderer.html
@@ -5,7 +5,7 @@
         <img ui-tree-handle="" src="{{ static('report_builder/img/reorder.svg') }}"></img>
         <img ng-click="deleteField(this)" src="{{ static('report_builder/img/delete.svg') }}"></img>
       </div>
-      <div flex="" class="caps">
+      <div title="{{ field.path + field.field }}" flex="" class="caps">
         <span ng-if="field.path_verbose">({{ field.path_verbose }}) </span>
         {{ field.field_verbose }}
       </div>
@@ -30,7 +30,12 @@
         <div ng-switch-when="isnull">
           <md-checkbox ng-model="field.filter_value" ng-true-value="'True'" aria-label="Is Null">
         </div>
-
+        <div ng-switch-when="max">
+         <md-checkbox ng-model="field.filter_value" ng-true-value="'True'" aria-label="Max (annotation-filter)">
+        </div>
+        <div ng-switch-when="min">
+          <md-checkbox ng-model="field.filter_value" ng-true-value="'True'" aria-label="Min (annotation-filter)">
+        </div>
         <div ng-switch-default ng-switch="field.field_type">
           <input ng-switch-when="DateField" pikaday="pikaday" format="YYYY-MM-DD" ng-model="field.filter_value"></input>
           <div ng-switch-when="BooleanField">

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -784,6 +784,34 @@ class ReportTests(TestCase):
         self.assertContains(response, '"path":"restaurant__"')
 
     def test_annotation_filter_min(self):
+        """
+        Similar to group-by queries, annotation-filters allow you to display only
+        the Max or Min of a set of rows.
+
+        Suppose we have two models, Person and Child. Each has first_name,
+        last_name fields and Child has a foreign key to Person as parent. Child
+        also has age and color fields. Already we can use the group-by
+        mechanism to display each Person's count of children or the age of each
+        person's oldest child.
+
+        Unfortunately, getting the related items of an aggregate is difficult
+        in Django and SQL. Suppose in the example above that we want to know
+        the name and age of each person's oldest child. With annotation-filters
+        this can be done.
+
+        Annotation-filters are applied iteratively after normal queryset
+        filtering. They work, as the name indicates, by applying Django's
+        annotate and filter queryset methods. As they are self-referential,
+        they do not accept a text input from the front-end.
+
+        Annotation-filters are difficult to describe conceptually so I'll use
+        an example. To display the name and age of each person's oldest child,
+        we begin by constructing a report based on Child. We add display fields
+        for the parent name, child name, and child age. Then for filter fields,
+        we add the parent__children__age field. This lengthy path indicates
+        that children are to be grouped by their parent and with the type Max,
+        only the maximum age of each group should be included.
+        """
         self.make_people()
 
         model = ContentType.objects.get(model='child')
@@ -846,6 +874,13 @@ class ReportTests(TestCase):
         self.assertContains(response, data)
 
     def test_annotation_filter_max(self):
+        """
+        See test_annotation_filter_min for a description of annotation-filters.
+
+        This test extends things further by adding the filter field
+        parent__children__color with type Equals Red to get a list of the
+        oldest children of each person whose favorite color is red.
+        """
         self.make_people()
 
         model = ContentType.objects.get(model='child')


### PR DESCRIPTION
Similar to group-by queries, annotation-filters allow you to display only the Max or Min of a set of rows.

Suppose we have two models, Person and Child. Each has `first_name`, `last_name` fields and Child has a foreign key to Person as `parent`. Child also has `age` and `color` fields. Already we can use the group-by mechanism to display each Person's count of children or the age of each person's oldest child.

Unfortunately, getting the related items of an aggregate is difficult in Django and SQL. Suppose in the example above that we want to know the name and age of each person's oldest child. With annotation-filters this can be done.

Annotation-filters are applied iteratively after normal queryset filtering. They work, as the name indicates, by applying Django's annotate and filter queryset methods. As they are self-referential, they do not accept a text input from the front-end.

Annotation-filters are difficult to describe conceptually so I'll use an example. To display the name and age of each person's oldest child, we begin by constructing a report based on Child. We add display fields for the parent name, child name, and child age. Then for filter fields, we add the `parent__children__age` field. This lengthy path indicates that children are to be grouped by their parent and with the type `Max`, only the maximum age of each group should be included.

We could extend this further by adding the filter field `parent__children__color` with type `Equals` `Red` to get a list of the oldest children of each person whose favorite color is red.

This change extends the tests based on Person and Child with coverage for the above described scenarios.