### PR TITLE
Staff member

### DIFF
--- a/report_builder/urls.py
+++ b/report_builder/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import patterns, url, include
-from django.contrib.admin.views.decorators import staff_member_required
 from rest_framework import routers
 from . import views
 from .api import views as api_views
+from .utils import staff_member_required
 from django.conf import settings
 
 router = routers.DefaultRouter()
@@ -20,10 +20,10 @@ urlpatterns = patterns(
     url('^export_to_report/$', views.ExportToReport.as_view(), name="export_to_report"),
     url(r'^api/', include(router.urls)),
     url(r'^api/api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url('^report/(?P<pk>\d+)/$', views.ReportSPAView.as_view(), name="report_update_view"),
     url(r'^api/related_fields', staff_member_required(api_views.RelatedFieldsView.as_view()), name="related_fields"),
     url(r'^api/fields', staff_member_required(api_views.FieldsView.as_view()), name="fields"),
     url(r'^api/report/(?P<report_id>\w+)/generate/', staff_member_required(api_views.GenerateReport.as_view()), name="generate_report"),
-    url('^report/(?P<pk>\d+)/$', views.ReportSPAView.as_view(), name="report_update_view"),
 )
 
 if not hasattr(settings, 'REPORT_BUILDER_FRONTEND') or settings.REPORT_BUILDER_FRONTEND:

--- a/report_builder/utils.py
+++ b/report_builder/utils.py
@@ -1,3 +1,6 @@
+from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.conf import settings
 import copy
 
 
@@ -8,6 +11,27 @@ def javascript_date_format(python_date_format):
     if not format:
         format = 'yyyy-mm-dd'
     return format
+
+
+def staff_member_required(view_func=None,
+                          redirect_field_name=REDIRECT_FIELD_NAME,
+                          login_url='admin:login'):
+    if (not hasattr(settings, 'REPORT_BUILDER_STAFF_REQUIRED') or
+            settings.REPORT_BUILDER_STAFF_REQUIRED):
+        actual_decorator = user_passes_test(
+            lambda u: u.is_active and u.is_staff,
+            login_url=login_url,
+            redirect_field_name=redirect_field_name
+        )
+    else:
+        actual_decorator = user_passes_test(
+            lambda u: u.is_active,
+            login_url=login_url,
+            redirect_field_name=redirect_field_name
+        )
+    if view_func:
+        return actual_decorator(view_func)
+    return actual_decorator
 
 
 def duplicate(obj, changes=None):

--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -2,7 +2,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
 from django.core.mail import send_mail, EmailMultiAlternatives
 from django.core.files.base import ContentFile
-from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth import get_user_model
 from django.template.loader import get_template
 from django.template import Context
@@ -13,7 +12,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView, View
 from six import string_types
 
-from .utils import duplicate
+from .utils import duplicate, staff_member_required
 from .models import Report
 from report_utils.mixins import DataExportMixin, generate_filename
 
@@ -239,7 +238,7 @@ class ExportToReport(DownloadFileView, TemplateView):
 
 @staff_member_required
 def check_status(request, pk, task_id):
-    """ Check if the asyncronous report is ready to download """
+    """ Check if the asynchronous report is ready to download """
     from celery.result import AsyncResult
     res = AsyncResult(task_id)
     link = ''


### PR DESCRIPTION
We're having some issues because we built out our authentication access ourselves, and technically people aren't "staff members" for us. They are authenticated through Google apps, and they are logged in when they have the domain extension signed in from there. 

I have added the ability to disable `REPORT_BUILDER_STAFF_REQUIRED` as we can't get this to work without having this turned off. We have to grant the current users staff member access, but as we increase the number of people using it - we would like to disable this feature. 

Let me know if your thoughts! Happy to improve/optimize sections of this.