### PR TITLE
Enable Pikaday widget on datetime fields

### DIFF
--- a/report_builder/static/report_builder/partials/filter_renderer.html
+++ b/report_builder/static/report_builder/partials/filter_renderer.html
@@ -38,6 +38,7 @@
         </div>
         <div ng-switch-default ng-switch="field.field_type">
           <input ng-switch-when="DateField" pikaday="pikaday" format="YYYY-MM-DD" ng-model="field.filter_value"></input>
+          <input ng-switch-when="DateTimeField" pikaday="pikaday" format="YYYY-MM-DD" ng-model="field.filter_value"></input>
           <div ng-switch-when="BooleanField">
             <md-checkbox ng-model="field.filter_value">
           </div>

--- a/report_builder/static/report_builder/partials/filter_renderer.html
+++ b/report_builder/static/report_builder/partials/filter_renderer.html
@@ -45,6 +45,7 @@
           <input ng-switch-default type="text" ng-model="field.filter_value"></input>
           <div ng-if="field.filter_type == 'range'" flex="" ng-switch="field.field_type">
             <input ng-switch-when="DateField" pikaday="pikaday" format="YYYY-MM-DD" ng-model="field.filter_value2"></input>
+            <input ng-switch-when="DateTimeField" pikaday="pikaday" format="YYYY-MM-DD" ng-model="field.filter_value2"></input>
             <input ng-switch-default type="text" ng-model="field.filter_value2"></input>
           </div>
         </div>


### PR DESCRIPTION
Because entering date manually according to the specified format is difficult for end users.