### PR TITLE
Property insertion order

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -168,11 +168,11 @@ class Report(models.Model):
                 display_field.total_count = Decimal(0.0)
                 display_totals.append(display_field)
             display_field_type = display_field.field_type
+            i += 1
             if display_field_type == "Property":
                 display_field_properties.append(display_field.field_key)
                 insert_property_indexes.append(i)
             else:
-                i += 1
                 if display_field.aggregate:
                     display_field_paths += [
                         display_field.field_key +

--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -168,7 +168,6 @@ class Report(models.Model):
                 display_field.total_count = Decimal(0.0)
                 display_totals.append(display_field)
             display_field_type = display_field.field_type
-            i += 1
             if display_field_type == "Property":
                 display_field_properties.append(display_field.field_key)
                 insert_property_indexes.append(i)
@@ -179,6 +178,7 @@ class Report(models.Model):
                         '__' + display_field.aggregate.lower()]
                 else:
                     display_field_paths += [display_field.field_key]
+            i += 1
 
             # Build display choices list
             if display_field.choices and hasattr(display_field, 'choices_dict'):

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -305,7 +305,7 @@ class ReportTests(TestCase):
         self.generate_url = reverse('generate_report', args=[self.report.id])
 
     def test_property_position(self):
-        bar = Bar()
+        bar = self.bar
 
         DisplayField.objects.create(
             report=self.report,
@@ -323,6 +323,36 @@ class ReportTests(TestCase):
         self.assertEqual(
             report_list[0],
             [bar.i_want_char_field, bar.i_need_char_field]
+        )
+
+    def test_property_and_field_position(self):
+        bar = self.bar
+
+        DisplayField.objects.create(
+            report=self.report,
+            field="char_field",
+            field_verbose="stuff",
+        )
+        DisplayField.objects.create(
+            report=self.report,
+            field="i_want_char_field",
+            field_verbose="stuff",
+        )
+        DisplayField.objects.create(
+            report=self.report,
+            field="i_need_char_field",
+            field_verbose="stuff",
+        )
+        DisplayField.objects.create(
+            report=self.report,
+            field="char_field",
+            field_verbose="stuff",
+        )
+
+        report_list = self.report.report_to_list(self.report.get_query())
+        self.assertEqual(
+            report_list[0],
+            [bar.char_field, bar.i_want_char_field, bar.i_need_char_field, bar.char_field]
         )
 
     def test_property_display(self):

--- a/report_builder/tests.py
+++ b/report_builder/tests.py
@@ -107,7 +107,7 @@ class UtilityFunctionTests(TestCase):
         self.assertTrue('distinct' in names)
         self.assertTrue('id' in names)
         self.assertEquals(len(names), 9)
-    
+
     def test_get_fields(self):
         """ Test GetFieldsMixin.get_fields """
         obj = GetFieldsMixin()
@@ -303,6 +303,27 @@ class ReportTests(TestCase):
         self.report = Report.objects.create(root_model=ct, name="A")
         self.bar = Bar.objects.create(char_field="wooo")
         self.generate_url = reverse('generate_report', args=[self.report.id])
+
+    def test_property_position(self):
+        bar = Bar()
+
+        DisplayField.objects.create(
+            report=self.report,
+            field="i_want_char_field",
+            field_verbose="stuff",
+            position=1,
+        )
+        DisplayField.objects.create(
+            report=self.report,
+            field="i_need_char_field",
+            field_verbose="stuff",
+            position=2,
+        )
+        report_list = self.report.report_to_list(self.report.get_query())
+        self.assertEqual(
+            report_list[0],
+            [bar.i_want_char_field, bar.i_need_char_field]
+        )
 
     def test_property_display(self):
         DisplayField.objects.create(


### PR DESCRIPTION
Currently using multiple properties will have them inserted in the result list in the wrong order.

I created a failing test, and resolved it.