### PR TITLE
Type-o fixes

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -88,7 +88,7 @@ class Report(models.Model):
         AUTH_USER_MODEL, blank=True,
         help_text="These users have starred this report for easy reference.",
         related_name="report_starred_set")
-    
+
     def __str__(self):
         return self.name
 
@@ -470,7 +470,7 @@ class Report(models.Model):
             if user is None:
                 raise Exception('Cannot run async report without a user')
             self.async_report_save(
-                self, objects_list, title, header, widths, user, file_type)
+                objects_list, title, header, widths, user, file_type)
         else:
             if file_type == 'csv':
                 return data_export.list_to_csv_response(

--- a/report_builder/views.py
+++ b/report_builder/views.py
@@ -66,7 +66,7 @@ class DownloadFileView(DataExportMixin, View):
         if to_response:
             return report.run_report(file_type, user, queryset)
         else:
-            report.run_report(user, file_type, queryset, async=True)
+            report.run_report(file_type, user, queryset, async=True)
 
     def get(self, request, *args, **kwargs):
         report_id = kwargs['pk']


### PR DESCRIPTION
+ `self` was being passed to `async_report_save` which caused problems when saving the `FileField`.

+ Argument order change to fix: 

    ```python
    File "report-builder/report_builder/mixins.py", line 201, in can_change_or_view
         can_change = user.has_perm(app_label + '.change_' + model_name)
    AttributeError: 'str' object has no attribute 'has_perm'
    ```
+ Whitespace

+ `docker-compose run --rm web python manage.py test` passed 👍.

+ `docker-compose run --rm web tox` passed 👍.