### PR TITLE
Fix exclusion of fields from root model and related fields

### DIFF
--- a/report_builder/api/tests.py
+++ b/report_builder/api/tests.py
@@ -1,0 +1,39 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+import json
+
+
+class ApiTestCase(TestCase):
+
+    def setUp(self):
+        self.su = get_user_model().objects.create_superuser('su', 'su@example.com', 'su')
+        self.client = APIClient()
+
+    def get_child_related_fields(self):
+        self.client.login(username='su', password='su')
+        ct = ContentType.objects.get_by_natural_key('demo_models', 'child')
+        response = self.client.post(
+            reverse('related_fields'),
+            {'field': '', 'model': ct.id, 'path': ''},
+            format='json'
+        )
+        self.assertEqual(response.status_code, 200)
+        return response
+
+    def test_related_fields(self):
+        response = self.get_child_related_fields()
+        related_fields = json.loads(response.content)
+        self.assertEqual(len(related_fields), 1)
+        self.assertEqual(related_fields[0]['field_name'], 'parent')
+        self.assertTrue(related_fields[0]['included_model'])
+
+    @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.parent'])
+    def test_related_fields_exclude(self):
+        response = self.get_child_related_fields()
+        related_fields = json.loads(response.content)
+        self.assertEqual(len(related_fields), 1)
+        self.assertEqual(related_fields[0]['field_name'], 'parent')
+        self.assertFalse(related_fields[0]['included_model'])

--- a/report_builder/api/tests.py
+++ b/report_builder/api/tests.py
@@ -30,7 +30,7 @@ class ApiTestCase(TestCase):
         self.assertEqual(related_fields[0]['field_name'], 'parent')
         self.assertTrue(related_fields[0]['included_model'])
 
-    @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.parent'])
+    @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.person'])
     def test_related_fields_exclude(self):
         response = self.get_child_related_fields()
         related_fields = json.loads(response.content)

--- a/report_builder/api/tests.py
+++ b/report_builder/api/tests.py
@@ -9,48 +9,62 @@ import json
 class ApiTestCase(TestCase):
 
     def setUp(self):
-        self.su = get_user_model().objects.create_superuser('su', 'su@example.com', 'su')
+        um = get_user_model()
+        self.superuser = um.objects.create_superuser('su', 'su@example.com', 'su')
+        self.regularuser = um.objects.create_user('user', 'user@example.com', 'user')
         self.client = APIClient()
 
-    def get_child_related_fields(self):
+    def get_json(self, url):
         self.client.login(username='su', password='su')
-        ct = ContentType.objects.get_by_natural_key('demo_models', 'child')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        return content
+
+    def post_json(self, url, data):
         response = self.client.post(
-            reverse('related_fields'),
-            {'field': '', 'model': ct.id, 'path': ''},
+            url,
+            data,
             format='json'
         )
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
         return content
 
+    def test_endpoint_not_accessable_by_regular_user(self):
+        self.client.login(username='user', password='user')
+        response = self.client.get('/report_builder/api/contenttypes/')
+        self.assertEqual(response.status_code, 403)
+
+    def get_related_fields_for_ct(self, app_label, model_name):
+        self.client.login(username='su', password='su')
+        ct = ContentType.objects.get_by_natural_key(app_label, model_name)
+        content = self.post_json(
+            reverse('related_fields'),
+            {'field': '', 'model': ct.id, 'path': ''},
+        )
+        return content
+
     def test_related_fields(self):
-        related_fields = self.get_child_related_fields()
+        related_fields = self.get_related_fields_for_ct('demo_models', 'child')
         self.assertEqual(len(related_fields), 1)
         self.assertEqual(related_fields[0]['field_name'], 'parent')
         self.assertTrue(related_fields[0]['included_model'])
 
     @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.person'])
     def test_related_fields_exclude(self):
-        related_fields = self.get_child_related_fields()
+        related_fields = self.get_related_fields_for_ct('demo_models', 'child')
         self.assertEqual(len(related_fields), 1)
         self.assertEqual(related_fields[0]['field_name'], 'parent')
         self.assertFalse(related_fields[0]['included_model'])
 
-    def get_content_types(self):
-        self.client.login(username='su', password='su')
-        response = self.client.get('/report_builder/api/contenttypes/')
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-        return content
-
     def test_get_all_content_types(self):
         num_content_types = ContentType.objects.count()
-        response = self.get_content_types()
+        response = self.get_json('/report_builder/api/contenttypes/')
         self.assertEqual(len(response), num_content_types)
 
     @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.person'])
     def test_get_content_types_with_exclude(self):
         num_content_types = ContentType.objects.count()
-        response = self.get_content_types()
+        response = self.get_json('/report_builder/api/contenttypes/')
         self.assertEqual(len(response), num_content_types - 1)

--- a/report_builder/api/tests.py
+++ b/report_builder/api/tests.py
@@ -21,19 +21,36 @@ class ApiTestCase(TestCase):
             format='json'
         )
         self.assertEqual(response.status_code, 200)
-        return response
+        content = json.loads(response.content)
+        return content
 
     def test_related_fields(self):
-        response = self.get_child_related_fields()
-        related_fields = json.loads(response.content)
+        related_fields = self.get_child_related_fields()
         self.assertEqual(len(related_fields), 1)
         self.assertEqual(related_fields[0]['field_name'], 'parent')
         self.assertTrue(related_fields[0]['included_model'])
 
     @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.person'])
     def test_related_fields_exclude(self):
-        response = self.get_child_related_fields()
-        related_fields = json.loads(response.content)
+        related_fields = self.get_child_related_fields()
         self.assertEqual(len(related_fields), 1)
         self.assertEqual(related_fields[0]['field_name'], 'parent')
         self.assertFalse(related_fields[0]['included_model'])
+
+    def get_content_types(self):
+        self.client.login(username='su', password='su')
+        response = self.client.get('/report_builder/api/contenttypes/')
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content)
+        return content
+
+    def test_get_all_content_types(self):
+        num_content_types = ContentType.objects.count()
+        response = self.get_content_types()
+        self.assertEqual(len(response), num_content_types)
+
+    @override_settings(REPORT_BUILDER_EXCLUDE=['demo_models.person'])
+    def test_get_content_types_with_exclude(self):
+        num_content_types = ContentType.objects.count()
+        response = self.get_content_types()
+        self.assertEqual(len(response), num_content_types - 1)

--- a/report_builder/api/views.py
+++ b/report_builder/api/views.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
-from ..models import Report, Format, FilterField
+from ..models import Report, Format, FilterField, get_allowed_models
 from .serializers import (
     ReportNestedSerializer, ReportSerializer, FormatSerializer,
     FilterFieldSerializer, ContentTypeSerializer)
@@ -57,8 +57,10 @@ class ContentTypeViewSet(ReportBuilderViewMixin, viewsets.ReadOnlyModelViewSet):
     """ Read only view of content types.
     Used to populate choices for new report root model.
     """
-    queryset = ContentType.objects.all()
     serializer_class = ContentTypeSerializer
+
+    def get_queryset(self):
+        return get_allowed_models()
 
 
 class ReportViewSet(ReportBuilderViewMixin, viewsets.ModelViewSet):

--- a/report_builder/urls.py
+++ b/report_builder/urls.py
@@ -10,7 +10,7 @@ router.register(r'reports', api_views.ReportViewSet)
 router.register(r'report', api_views.ReportNestedViewSet)
 router.register(r'formats', api_views.FormatViewSet)
 router.register(r'filterfields', api_views.FilterFieldViewSet)
-router.register(r'contenttypes', api_views.ContentTypeViewSet)
+router.register(r'contenttypes', api_views.ContentTypeViewSet, base_name='contenttypes')
 
 urlpatterns = [
     url(r'^report/(?P<pk>\d+)/download_file/$', views.DownloadFileView.as_view(), name="report_download_file"),


### PR DESCRIPTION
Started using this recently and really impressed with it, noticed some issues with the exclusion of models though

- Fixes exclusion of models from the content types endpoint
- Fixes included_model on /api/realted_fields/
- Adds unit tests for both cases

fixes #281 and fixes #268 