### PR TITLE
Corrected import location

### DIFF
--- a/report_builder/models.py
+++ b/report_builder/models.py
@@ -2,12 +2,11 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
+from django.core.exceptions import ValidationError, ObjectDoesNotExist, FieldDoesNotExist
 from django.utils.safestring import mark_safe
 from django.utils.functional import cached_property
 from django.db import models
 from django.db.models import Avg, Min, Max, Count, Sum, F
-from django.db.models.fields import FieldDoesNotExist
 from report_builder.unique_slugify import unique_slugify
 from .utils import (
     get_model_from_path_string, sort_data, increment_total, formatter)

--- a/report_builder/utils.py
+++ b/report_builder/utils.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from itertools import chain
 from numbers import Number
 from django.contrib.contenttypes.models import ContentType
-from django.db.models.fields import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.conf import settings
 import copy
 import datetime

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="django-report-builder",
-    version="6.3.2",
+    version="6.3.2.1",
     author="David Burke",
     author_email="david@burkesoftware.com",
     description=("Query and Report builder for Django ORM"),


### PR DESCRIPTION
The `__init__.py` from `django.db.models.fields` no longer references `FieldDoesNotExist`. This exception exists in from `django.core.exceptions`, just like the other imported exceptions, and should reference that file.